### PR TITLE
add lisp indentation option

### DIFF
--- a/doc/yuck.txt
+++ b/doc/yuck.txt
@@ -42,6 +42,14 @@ Default: 1
 >
   let g:yuck_align_keywords = 0
 < 
+
+--------------------------------------------------------------------
+*lisp_indentation*
+Specify whether to prefer the Lisp indentation algorithm. See 'lisp'.
+Default: 0
+>
+  let g:yuck_lisp_indentation = 1
+<
 vim:ft=help
 
 

--- a/indent/yuck.vim
+++ b/indent/yuck.vim
@@ -42,6 +42,14 @@ let g:yuck_align_subforms = get(g:, 'yuck_align_subforms', 0)
 
 let g:yuck_align_keywords = get(g:, 'yuck_align_keywords', 1)
 
+let g:yuck_lisp_indentation = get(g:, 'yuck_lisp_indentation', 0)
+
+if g:yuck_lisp_indentation
+  setlocal indentexpr=
+  setlocal lisp
+  finish
+endif
+
 " Only define the function once.
 if exists('*GetYuckIndent')
     finish


### PR DESCRIPTION
This simple PR adds the option to use lisp indentation.

In my case, the current indentation file works horribly. So I thought it would be nice to be able to prefer the built-in lisp indentation.