### PR TITLE
Do not change iskeyword option

### DIFF
--- a/ftplugin/yuck.vim
+++ b/ftplugin/yuck.vim
@@ -8,7 +8,6 @@ set cpo&vim
 
 let b:undo_ftplugin = "setl com< cms< fo<"
 
-setlocal iskeyword=!,$,%,#,*,+,-,.,/,:,<,=,>,?,_,a-z,A-Z,48-57,128-247,124,126,38,94
 setlocal suffixesadd=.yuck
 setlocal comments=n:; commentstring=;\ %s
 setlocal formatoptions-=t


### PR DESCRIPTION
It is really annoying when your cursor jumps to unexpected places. We should not be setting this option.